### PR TITLE
change to kramdown, new github markdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ name: Austin Hackers Anonymous
 url: http://takeonme.org
 title: Austin Hackers Academy
 
-markdown: redcarpet
+markdown: kramdown
 pygments: true
 timezone: America/Chicago
 homepage: index.html

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ url: http://takeonme.org
 title: Austin Hackers Academy
 
 markdown: kramdown
-pygments: true
+highlighter: rouge
 timezone: America/Chicago
 homepage: index.html
 meetingpage: meetings.html


### PR DESCRIPTION
Github will no longer support other markdowns except kramdown. So we gotta switch.