### PR TITLE
Add security.txt because why not

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:todb@packetfu.com
+Expires: 2038-12-31T15:00:00.000Z
+Preferred-Languages: en
+Canonical: https://takeonme.org/.well-known/security.txt


### PR DESCRIPTION
Noticed that there's already a .well-known/ file in here, figured why not add a security.txt?

https://securitytxt.org/

Alternate contact addresses are totally allowed, I just didn't want to dox anyone like @mauvehed with a real email address just out of the blue.
