### PR TITLE
Update to rules 

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -13,8 +13,8 @@ There are five basic rules of AHA.
 1. What happens at AHA, stays at AHA.
 2. There is no recording or filming allowed.
 3. You must participate to remain a member.
-4. Keep your talk under 10 mins.
-5. Pitching product/company or recruiting for headcount? YOU MUST BUY BOOZE
+4. Keep your talk under 10 mins. Introductory talks (noob talks) should be very short.
+5. Pitching product/company or recruiting for headcount? YOU MUST BUY A ROUND FOR THE ENTIRE GROUP.
 
 1) Do not discuss presentations or conversations at AHA outside of the meeting, with anyone. Examples would include
 discussing presentations with a journalist, with your boss, or with a representative of a relevant vendor.


### PR DESCRIPTION
Dr Drake suggested there could be a clarification about the drink-buying rule. 

Noob clarification because it seeme3d like the noob talks got out of control at the March 2023 meeting. Noob talks are time to work on your stand up. Intro yourself, your interested, and sit down and STFU.

Update to rules to specify that noob talks should be short, and to clarify that people doing job pitches or product pitches are on the hook to buy a round for the group. Reviewers, make sure a few people agree with these rules changes, since the rules are foundational to the meetings.