### PR TITLE
Fix the broken Fork Me image

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,7 +47,7 @@
               </center> </p>
             </div>
           </div>
-            <a href="https://github.com/you"><img decoding="async" loading="lazy" width="149" height="149" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_green_007200.png?resize=149%2C149" class="attachment-full size-full" alt="Fork me on GitHub" data-recalc-dims="1" style="position: absolute; top: 0; right: 0; border: 0;"></a>	
+            <a href="https://github.com/AustinHackers/austinhackers.github.io"><img decoding="async" loading="lazy" width="149" height="149" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_green_007200.png?resize=149%2C149" class="attachment-full size-full" alt="Fork me on GitHub" data-recalc-dims="1" style="position: absolute; top: 0; right: 0; border: 0;"></a>	
         </div>
         {% include text-expand.html %}
     </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,8 +47,7 @@
               </center> </p>
             </div>
           </div>
-					<a href="https://github.com/AustinHackers/austinhackers.github.io"><img style="position: absolute; top: 0; right: 0; border: 0;"
-						src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a>
+            <a href="https://github.com/you"><img decoding="async" loading="lazy" width="149" height="149" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_green_007200.png?resize=149%2C149" class="attachment-full size-full" alt="Fork me on GitHub" data-recalc-dims="1" style="position: absolute; top: 0; right: 0; border: 0;"></a>	
         </div>
         {% include text-expand.html %}
     </body>


### PR DESCRIPTION
At some point, the "Fork me on Github" ribbon got broke. Got a new one from https://github.blog/2008-12-19-github-ribbons/

Before and after:

![image](https://github.com/AustinHackers/austinhackers.github.io/assets/24144/7cc5909e-d8ca-4ad8-8773-f10094fb288a)
