### PR TITLE
Update exploitability per the Wireshark bug

### DIFF
--- a/cves/CVE-2023-0667.md
+++ b/cves/CVE-2023-0667.md
@@ -13,7 +13,7 @@ Any questions about this disclosure should be directed to **cve@takeonme.org**.
 
 # Executive Summary
 
-Due to failure in validating the length provided by an attacker-crafted [MSMMS](https://wiki.wireshark.org/MSMMS.md) packet, Wireshark version 4.0.5 and prior, by default, is susceptible to a heap-based buffer overflow, and possibly code execution in the context of the process running Wireshark. [CVE-2023-0667] appears to be an instance of [CWE-122].
+Due to failure in validating the length provided by an attacker-crafted [MSMMS](https://wiki.wireshark.org/MSMMS.md) packet, Wireshark version 4.0.5 and prior, in an unusual configuration, is susceptible to a heap-based buffer overflow, and possibly code execution in the context of the process running Wireshark. [CVE-2023-0667] appears to be an instance of [CWE-122].
 
 # Technical Details
 


### PR DESCRIPTION
See https://gitlab.com/wireshark/wireshark/-/issues/19086#note_1400755665

Quoting John Thacker:

> Technically it is possible to run a production release with WIRESHARK_DEBUG_WMEM_OVERRIDE=simple and get the buffer overread, but that doesn't really fall into the category of "a unsuspecting naive user could hit this."

> The block allocator (especially the fast one) has the nice (side?) effect of making buffer overflows somewhat less likely in normal use.

So, you need to be doing something weird in order to get popped by this -- namely, running in debug mode, or running fuzzshark, or something like that. Not as straightforward as CVE-2023-0666 and CVE-2023-0668.
