### PR TITLE
fix(meetings.html): update October meeting date and highlight it

### DIFF
--- a/_layouts/meetings.html
+++ b/_layouts/meetings.html
@@ -46,7 +46,7 @@ layout: default
 		<li>Jul 25, 2024 - <a href="meetings.html">0x00d6</a></li>
 		<li>Aug 29, 2024 - <a href="meetings.html">0x00d7</a></li>
 		<li>Sep 26, 2024 - <a href="meetings.html">0x00d8</a></li>
-		<li>Oct 31, 2024 - <a href="meetings.html">0x00d9</a> (🎃)</li>
+		<li><font color="orange">Oct 24, 2024 - <a href="meetings.html">0x00d9</a> (🎃) 1 week early</font></li>
 		<li>Nov 28, 2024 - <a href="meetings.html">0x00da</a> (🦃)</li>
 		<li>Dec 26, 2024 - <a href="meetings.html">0x00db</a></li>
 	  </ul>


### PR DESCRIPTION
The October meeting date was moved one week earlier to October 24, 2024. The change was highlighted in orange to draw attention to this important update. This change was necessary to avoid scheduling conflicts and ensure maximum attendance.