### PR TITLE
docs(coc.md): add Code of Conduct for Austin Hackers Association

### DIFF
--- a/coc.md
+++ b/coc.md
@@ -1,0 +1,56 @@
+---
+layout: default
+title: Code of Conduct
+categories: nav
+showinnav: true
+---
+
+# {{ page.title }}
+
+## Austin Hackers Association (AHA!) Code of Conduct
+
+Welcome to AHA! If you’re here, you already know this isn’t your typical buttoned-up tech meetup. We swear, we heckle, and we’re all just here to have a great f\*\\*\*ing time. But even in our chaotic little corner, we have some ground rules.
+
+#### Roast the Ideas, Not the Person
+
+>> Got a hot take? Bring it. Got a dumb take? Expect to hear about it. But keep it fun. Don’t be a d\*\*k to the person; they’re here to learn and blow off steam just like you.
+
+#### No Creeps, No Bullies, No Exceptions
+
+>> We don’t f\*\* around with harassment, discrimination, or any of that other crap. If you make someone feel uncomfortable based on who they are, you’re out. Full stop. Play nice or don’t play here.
+
+#### Keep Our St Here\*\*
+
+>> What happens at AHA! stays at AHA! This isn’t Twitter or some confessional blog. Respect people’s privacy, and don’t be the a\*\*hole who spills stuff outside these walls.
+
+#### Own Your S\*\*t and Move On\*\*
+
+>> We’re not saints, but we are accountable. If you mess up, just admit it and fix it. Don’t double down or play dumb. We’re all here to learn, so act like it.
+
+#### Go Nuts, But Don’t Get Us Arrested
+
+>> Bring your wildest energy and loudest voice—hell, we expect it. Just don’t cross that line where it turns into a legal nightmare. You know where the line is… we think.
+
+### How we handle violations
+
+We’re serious about creating a fun and inclusive space where everyone can feel safe being themselves. If these rules get broken, here’s how we deal with it:
+
+#### Step One: A Quiet Word
+
+>> For minor violations, you’ll get a direct heads-up from one of the organizers. They’ll let you know what’s up and how to keep it chill moving forward.
+
+#### Step Two: Time-Out
+
+>> For repeated or more serious issues, you might be asked to step away from the event for the night. This isn’t middle school—we’ll treat you like an adult, but we’ll also hold you accountable.
+
+#### Step Three: Bye Forever
+
+>> Major violations (e.g., harassment, discrimination, breaking the “No Creeps, No Bullies” rule) mean you’re permanently out. No debate, no appeal, no re-entry.
+
+#### Confidential Reporting
+
+>> If you experience or witness something that doesn’t sit right, talk to an organizer in person or message us privately. We’ll handle it discreetly and follow up. No drama, no spotlight, just action.
+
+### Mob Rule
+
+We hold ourselves to these same standards. If an organizer messes up, call us out—we’ll own it and make it right. At the end of the day, the Mob is who rules AHA. What the masses decide is what happens.


### PR DESCRIPTION
Introduce a Code of Conduct document to establish guidelines for behavior
at Austin Hackers Association events. The document outlines expectations
for respectful interaction, privacy, accountability, and handling of
violations. It aims to create a fun, inclusive, and safe environment for
all participants by setting clear rules and consequences for misconduct.