### PR TITLE
update with 2025 dates

### DIFF
--- a/_layouts/meetings.html
+++ b/_layouts/meetings.html
@@ -37,18 +37,19 @@ layout: default
 	</p>
 <p>
 	<ul>
-		<li>Jan 25, 2024 - <a href="meetings.html">0x00d0</a></li>
-		<li>Feb 29, 2024 - <a href="meetings.html">0x00d1</a></li>
-		<li>Mar 28, 2024 - <a href="meetings.html">0x00d2</a></li>
-		<li>Apr 25, 2024 - <a href="meetings.html">0x00d3</a></li>
-		<li>May 30, 2024 - <a href="meetings.html">0x00d4</a></li>
-		<li>Jun 27, 2024 - <a href="meetings.html">0x00d5</a></li>
-		<li>Jul 25, 2024 - <a href="meetings.html">0x00d6</a></li>
-		<li>Aug 29, 2024 - <a href="meetings.html">0x00d7</a></li>
-		<li>Sep 26, 2024 - <a href="meetings.html">0x00d8</a></li>
-		<li><font color="orange">Oct 24, 2024 - <a href="meetings.html">0x00d9</a> (🎃) 1 week early</font></li>
-		<li><font color="785C33">Nov 21, 2024 - <a href="meetings.html">0x00da</a> (🦃) 1 week early</font></li>
 		<li>Dec 26, 2024 - <a href="meetings.html">0x00db</a></li>
+		<li>Jan 30, 2025 - <a href="meetings.html">0x00dc</a></li>
+		<li>Feb 27, 2025 - <a href="meetings.html">0x00dd</a></li>
+		<li>Mar 27, 2025 - <a href="meetings.html">0x00de</a></li>
+		<li>Apr 24, 2025 - <a href="meetings.html">0x00df</a></li>
+		<li>May 29, 2025 - <a href="meetings.html">0x00e0</a></li>
+		<li>Jun 26, 2025 - <a href="meetings.html">0x00e1</a></li>
+		<li>Jul 31, 2025 - <a href="meetings.html">0x00e2</a></li>
+		<li>Aug 28, 2025 - <a href="meetings.html">0x00e3</a></li>
+		<li>Sep 25, 2025 - <a href="meetings.html">0x00e4</a></li>
+		<li>Oct 30, 2025 - <a href="meetings.html">0x00e5</a></li>
+		<li><font color="785C33">Nov 20, 2025 - <a href="meetings.html">0x00e6</a> (🦃) 1 week early</font></li>
+		<li><font color="3C8D0D">Dec 18, 2025 - <a href="meetings.html">0x00e7</a> (🎄) 1 week early</font></li>
 	  </ul>
 </p>
 <p>


### PR DESCRIPTION
As per #198. Kept the last event in 2024 since this PR is happening before it occurs. Speculatively moved the November and December meetings back a week, as they both fall on major holidays.