### PR TITLE
feat(logo.html): update logo to use image instead of text

### DIFF
--- a/themes/terminal/layouts/partials/logo.html
+++ b/themes/terminal/layouts/partials/logo.html
@@ -1,5 +1,6 @@
 <a href="{{ if $.Site.Params.Logo.LogoHomeLink }}{{ $.Site.Params.Logo.LogoHomeLink }}{{else}}{{ $.Site.BaseURL }}{{ end }}">
   <div class="logo">
-    {{ with $.Site.Params.Logo.logoText }}{{ . }}{{ else }}Terminal{{ end }}
+    <img src="/images/AHA-logo-black.png" alt="AHA! Logo" height="100">
+    <!-- {{ with $.Site.Params.Logo.logoText }}{{ . }}{{ else }}Terminal{{ end }} -->
   </div>
 </a>


### PR DESCRIPTION
Replace the text-based logo with an image to enhance the visual appearance and brand recognition. The image is sourced from "/images/AHA-logo-black.png" and provides a more professional and consistent look across different platforms. The previous text-based logo code is commented out for potential future use or reference.