### PR TITLE
Fix pubdate to publishdate

### DIFF
--- a/content/cves/CVE-2023-0666.md
+++ b/content/cves/CVE-2023-0666.md
@@ -1,7 +1,7 @@
 ---
 title: CVE-2023-0666 🤘
 aliases: ["/cves/CVE-2023-0666.html"]
-pubDate: 2023-06-06T13:37:00-05:00
+publishDate: 2023-06-06T13:37:00-05:00
 ---
 
 # CVE-2023-0666: Wireshark RTPS Parsing Buffer Overflow

--- a/content/cves/CVE-2023-0667.md
+++ b/content/cves/CVE-2023-0667.md
@@ -1,7 +1,7 @@
 ---
 title: CVE-2023-0667
 aliases: ["/cves/CVE-2023-0667.html"]
-pubDate: 2023-06-06T13:37:00-05:00
+publishDate: 2023-06-06T13:37:00-05:00
 ---
 
 # CVE-2023-0667: Wireshark MSMMS parsing buffer overflow

--- a/content/cves/CVE-2023-0668.md
+++ b/content/cves/CVE-2023-0668.md
@@ -1,7 +1,7 @@
 ---
 title: CVE-2023-0668
 aliases: ["/cves/CVE-2023-0668.html"]
-pubDate: 2023-06-06T13:37:00-05:00
+publishDate: 2023-06-06T13:37:00-05:00
 ---
 
 

--- a/content/cves/CVE-2023-2905.md
+++ b/content/cves/CVE-2023-2905.md
@@ -1,7 +1,7 @@
 ---
 title: CVE-2023-2905
 aliases: ["/cves/CVE-2023-2905.html"]
-pubDate: 2023-08-08T13:37:00-05:00
+publishDate: 2023-08-08T13:37:00-05:00
 ---
 
 # CVE-2023-2905: Cesanta Mongoose MQTT Message Parsing Heap Overflow

--- a/content/cves/CVE-2023-2906.md
+++ b/content/cves/CVE-2023-2906.md
@@ -1,7 +1,7 @@
 ---
 title: CVE-2023-2906
 aliases: ["/cves/CVE-2023-2906.html"]
-pubDate: 2023-08-24T13:37:00-05:00
+publishDate: 2023-08-24T13:37:00-05:00
 ---
 
 # CVE-2023-2906: Wireshark CP2179 Parsing Divide By Zero DoS

--- a/content/cves/CVE-2023-4504.md
+++ b/content/cves/CVE-2023-4504.md
@@ -1,7 +1,7 @@
 ---
 title: CVE-2023-4504
 aliases: ["/cves/CVE-2023-4504.html"]
-pubDate: 2023-09-21T13:37:00-05:00
+publishDate: 2023-09-21T13:37:00-05:00
 ---
 # CVE-2023-4504: OpenPrinting CUPS/libppd Postscript Parsing Heap Overflow
 

--- a/content/cves/CVE-2023-5841.md
+++ b/content/cves/CVE-2023-5841.md
@@ -1,7 +1,7 @@
 ---
 title: CVE-2023-5841
 aliases: ["/cves/CVE-2023-5841.html"]
-pubDate: 2024-01-31T13:37:00-05:00
+publishDate: 2024-01-31T13:37:00-05:00
 ---
 
 # CVE-2023-5841: Academy Software Foundation OpenEXR Heap Overflow in Scanline Deep Data Parsing

--- a/content/cves/CVE-2024-4224.md
+++ b/content/cves/CVE-2024-4224.md
@@ -1,7 +1,7 @@
 ---
 title: CVE-2024-4224
 aliases: ["/cves/CVE-2024-4224.html"]
-pubDate: 2024-07-15T14:34:53.699-05:00
+publishDate: 2024-07-15T14:34:53.699-05:00
 ---
 
 # CVE-2024-4224: TP-Link TL-SG1016DE XSS

--- a/content/cves/CVE-2025-2894.md
+++ b/content/cves/CVE-2025-2894.md
@@ -2,7 +2,7 @@
 title: CVE-2025-2894
 aliases:
   - /cves/CVE-2025-2894.html
-pubDate: 2025-03-27T20:57:13-05:00
+publishDate: 2025-03-27T20:57:13-05:00
 ---
 
 # CVE-2025-2894: Unitree Go1 Backdoor Control Channel

--- a/content/cves/CVE-2025-32455.md
+++ b/content/cves/CVE-2025-32455.md
@@ -2,7 +2,7 @@
 title: CVE-2025-32455
 aliases:
   - /cves/CVE-2025-32455.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-32455: ON Semiconductor Quantenna router_command.sh run_cmd Argument Injection

--- a/content/cves/CVE-2025-32456.md
+++ b/content/cves/CVE-2025-32456.md
@@ -2,7 +2,7 @@
 title: CVE-2025-32456
 aliases:
   - /cves/CVE-2025-32456.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-32456: ON Semiconductor Quantenna router_command.sh put_file_to_qtn Argument Injection

--- a/content/cves/CVE-2025-32457.md
+++ b/content/cves/CVE-2025-32457.md
@@ -2,7 +2,7 @@
 title: CVE-2025-32457
 aliases:
   - /cves/CVE-2025-32457.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-32457: ON Semiconductor Quantenna router_command.sh get_file_from_qtn Argument Injection

--- a/content/cves/CVE-2025-32458.md
+++ b/content/cves/CVE-2025-32458.md
@@ -2,7 +2,7 @@
 title: CVE-2025-32458
 aliases:
   - /cves/CVE-2025-32458.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-32458: ON Semiconductor Quantenna router_command.sh get_syslog_from_qtn Argument Injection

--- a/content/cves/CVE-2025-32459.md
+++ b/content/cves/CVE-2025-32459.md
@@ -2,7 +2,7 @@
 title: CVE-2025-32459
 aliases:
   - /cves/CVE-2025-32459.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-32459: ON Semiconductor Quantenna router_command.sh sync_time Argument Injection

--- a/content/cves/CVE-2025-3459.md
+++ b/content/cves/CVE-2025-3459.md
@@ -2,7 +2,7 @@
 title: CVE-2025-3459
 aliases:
   - /cves/CVE-2025-3459.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-3459: ON Semiconductor Quantenna transmit_file Argument Injection

--- a/content/cves/CVE-2025-3460.md
+++ b/content/cves/CVE-2025-3460.md
@@ -2,7 +2,7 @@
 title: CVE-2025-3460
 aliases:
   - /cves/CVE-2025-3460.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-3460: ON Semiconductor Quantenna set_tx_pow Argument Injection

--- a/content/cves/CVE-2025-3461.md
+++ b/content/cves/CVE-2025-3461.md
@@ -2,7 +2,7 @@
 title: CVE-2025-3461
 aliases:
   - /cves/CVE-2025-3461.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-3461: ON Semiconductor Quantenna Telnet Missing Authentication

--- a/content/cves/CVE-2025-35004.md
+++ b/content/cves/CVE-2025-35004.md
@@ -2,7 +2,7 @@
 title: CVE-2025-35004
 aliases:
   - /cves/CVE-2025-35004.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-35004: Microhard Bullet-LTE and IPn4Gii AT+MFIP Argument Injection

--- a/content/cves/CVE-2025-35005.md
+++ b/content/cves/CVE-2025-35005.md
@@ -2,7 +2,7 @@
 title: CVE-2025-35005
 aliases:
   - /cves/CVE-2025-35005.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-35005: Microhard Bullet-LTE and IPn4Gii AT+MFMAC Argument Injection

--- a/content/cves/CVE-2025-35006.md
+++ b/content/cves/CVE-2025-35006.md
@@ -2,7 +2,7 @@
 title: CVE-2025-35006
 aliases:
   - /cves/CVE-2025-35006.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 I​CVE-2025-35006: Microhard Bullet-LTE and IPn4Gii AT+MFPORTFWD Argument Injection
 

--- a/content/cves/CVE-2025-35007.md
+++ b/content/cves/CVE-2025-35007.md
@@ -2,7 +2,7 @@
 title: CVE-2025-35007
 aliases:
   - /cves/CVE-2025-35007.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-35007: Microhard Bullet-LTE and IPn4Gii AT+MFRULE Argument Injection

--- a/content/cves/CVE-2025-35008.md
+++ b/content/cves/CVE-2025-35008.md
@@ -2,7 +2,7 @@
 title: CVE-2025-35008
 aliases:
   - /cves/CVE-2025-35008.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-35008: Microhard Bullet-LTE and IPn4Gii AT+MMNAME Argument Injection

--- a/content/cves/CVE-2025-35009.md
+++ b/content/cves/CVE-2025-35009.md
@@ -2,7 +2,7 @@
 title: CVE-2025-35009
 aliases:
   - /cves/CVE-2025-35009.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-35009: Microhard Bullet-LTE and IPn4Gii AT+MNNETSP Argument Injection

--- a/content/cves/CVE-2025-35010.md
+++ b/content/cves/CVE-2025-35010.md
@@ -2,7 +2,7 @@
 title: CVE-2025-35010
 aliases:
   - /cves/CVE-2025-35010.html
-pubDate: 2025-06-08T15:58:51-05:00
+publishDate: 2025-06-08T15:58:51-05:00
 ---
 
 # CVE-2025-35010: Microhard Bullet-LTE and IPn4Gii AT+MNPINGTM Argument Injection


### PR DESCRIPTION
For whatever reason, to make the RSS work right, I landed on adding a `pubdate` to all CVEs. Yet, [the documentation](https://gohugo.io/methods/page/publishdate/) seems silent on this alias. This switches them all to a more standard frontmatter element, `publishDate`.

Also, I wonder why all my PRs end up mentioning 2e83c65 like every time these days. It never really changes a file, so it doesn't really matter, but maybe this'll finish that commit merge once and for all. ¯\\_(ツ)_/¯